### PR TITLE
Add a way to secure paths by regex

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,11 @@ After installing the package you will see 3 new settings in the `appSettings` se
 
 Use the `BasicAuthentication.Required` to quickly turn the authentication on or off while the username/password settings are self explanatory. Username is case-insensitive, password is case-sensitive.
 
+As an alternative to securing the entire site, you can specify a regular expression to match against the URL Path by replacing the `"BasicAuthentication.Required"` appSetting with something like the following:
+
+    <add key="BasicAuthentication.RequiredOnPathRegex" value="^\/my-protected-path" />
+    <add key="BasicAuthentication.RequiredOnPathRegex.IgnoreCase" value="true" />
+
 As this module was meant to secure WebApi's behind an Azure API Management, it only supports one username/password combination. No support for multiple users,
 
 


### PR DESCRIPTION
As an alternative to securing the entire site, you can specify a regular expression to match against the URL Path by replacing the `"BasicAuthentication.Required"` appSetting with something like the following:

    <add key="BasicAuthentication.RequiredOnPathRegex" value="^\/my-protected-path" />
    <add key="BasicAuthentication.RequiredOnPathRegex.IgnoreCase" value="true" />
